### PR TITLE
Fix the missing Cast icon in the Youtube App

### DIFF
--- a/resources/lib/tubecast/dial.py
+++ b/resources/lib/tubecast/dial.py
@@ -18,8 +18,8 @@ __device__ = '''<?xml version="1.0" encoding="utf-8"?>
         <device>
             <deviceType>urn:schemas-upnp-org:device:dail:1</deviceType>
             <friendlyName>{{ friendlyName }}</friendlyName>
-            <manufacturer>Google Inc.</manufacturer>
-            <modelName>Eureka Dongle</modelName>
+            <manufacturer>enen92</manufacturer>
+            <modelName>Kodi</modelName>
             <UDN>uuid:{{ uuid }}</UDN>
             <serviceList>
                 <service>

--- a/resources/lib/tubecast/dial.py
+++ b/resources/lib/tubecast/dial.py
@@ -18,8 +18,8 @@ __device__ = '''<?xml version="1.0" encoding="utf-8"?>
         <device>
             <deviceType>urn:schemas-upnp-org:device:dail:1</deviceType>
             <friendlyName>{{ friendlyName }}</friendlyName>
-            <manufacturer>enen92</manufacturer>
-            <modelName>Kodi</modelName>
+            <manufacturer>Kodi</manufacturer>
+            <modelName>tubecast</modelName>
             <UDN>uuid:{{ uuid }}</UDN>
             <serviceList>
                 <service>


### PR DESCRIPTION
When I changed these strings for some reason the Cast icon in the Youtube app appeared again. 
This should fix the issues reported in the Kodi forums, e.g.
- https://forum.kodi.tv/showthread.php?tid=329153&pid=2832420#pid2832420
- https://forum.kodi.tv/showthread.php?tid=329153&pid=2833865#pid2833865
- https://forum.kodi.tv/showthread.php?tid=329153&pid=2847983#pid2847983

I think the only important change is that I removed Google from the strings. Choosing any other strings should work too.