### PR TITLE
Retain playback position

### DIFF
--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -241,7 +241,8 @@ class YoutubeCastV1(object):
                 self.cur_list = video_ids.split(",")
                 # Set info on our custom player instance and request playback
                 self.player.setInfo(cur_video_id, self.ctt, self.cur_list_id, self.current_index)
-                self.player.play_from_youtube(kodibrigde.get_youtube_plugin_path(cur_video_id))
+                play_url = kodibrigde.get_youtube_plugin_path(cur_video_id, seek=data.get("currentTime", 0))
+                self.player.play_from_youtube(play_url)
             else:
                 logger.debug("Command ignored, already executed before")
 

--- a/resources/lib/tubecast/youtube/kodibrigde.py
+++ b/resources/lib/tubecast/youtube/kodibrigde.py
@@ -16,8 +16,8 @@ def set_kodi_volume(volume):
                              "params": {"volume": volume}, "id": 8})
 
 
-def get_youtube_plugin_path(videoid):
-    return "plugin://plugin.video.youtube/play/?video_id={}".format(videoid)
+def get_youtube_plugin_path(videoid, seek=0):  # type: (str, str) -> str
+    return "plugin://plugin.video.youtube/play/?video_id={}&seek={}".format(videoid, seek)
 
 
 def remote_connected(name):


### PR DESCRIPTION
Currently TubeCast straight up ignores the current progress of a video when you start casting, which is rather unfortunate. This PR aims to fix this.

Summary of the changes:
The "setPlaylist" command payload contains a "currentTime" value which is read and passed on to the YouTube Kodi plugin using the ["seek"](https://github.com/jdf76/plugin.video.youtube/blob/b1a56c8e97f62f9358ad317cee4f651fdf437637/resources/lib/youtube_plugin/youtube/helper/yt_play.py#L98) URL parameter.

Merging this resolves #16.