### PR TITLE
Seeking for paused player

### DIFF
--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -30,7 +30,7 @@ class CastPlayer(xbmc.Player):
 
     @staticmethod
     def getPlayingStatusCode():
-        return 2 if xbmc.getInfoLabel('Player.Paused') else 1
+        return 2 if xbmc.getCondVisibility('Player.Paused') else 1
 
     def onPlayBackStarted(self):
         self.playing = True


### PR DESCRIPTION
I was bothered by the fact that TubeCast doesn't allow seeking when the player is paused, so I set out to change it.

With these changes it's possible to seek when the video is paused. The sender (app) properly updates its progress and the video remains paused.
In addition, this seems to have solved the issue that the app sometimes doesn't update it's progress when seeking normally.

Overview of the changes:
- Fixed the `getPlayingStatusCode` method. It never returned 2, even if the player was paused. 
- Send a state update to 3 (LOADING) just before seeking. This seems to be necessary to make the app not ignore the message (If the state doesn't change the app ignores the entire message even if the current time changed).