### PR TITLE
avoid reverse dns from bottle

### DIFF
--- a/resources/lib/tubecast/chromecast.py
+++ b/resources/lib/tubecast/chromecast.py
@@ -28,6 +28,9 @@ class SilentWSGIRequestHandler(WSGIRequestHandler):
             # Avoid garbage on the kodi log
             pass
 
+    def address_string(self):
+        return self.client_address[0]
+
 
 class ThreadedWSGIServer(ThreadingMixIn, WSGIServer):
     """Multi-Threaded WSGI server"""


### PR DESCRIPTION
i hate to have to pair my device everytime i want to cast so i decided to fix the disappearing of the device in the youtube app. after a fucking whole day and night of debugging i discovered that the request handling made in bottle is too slow to serve the youtube app in a proper way.

its slow because bottle does a reverse dns on every request coming from an ip. usually its fixed any way but since chromecast.py is using a custom handler you got to overload the address_string function again to avoid the reverse dns.

for me its working fine now, i hope ive helped somebody