### PR TITLE
Various Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Support will only be provided via the forum thread in [Kodi's Forums](https://fo
 
 ### Known issues
 
-* If you have a video queue set and attempt to stop playback from Kodi the next video on the queue will be played. Make sure you clear the playlist from the youtube application itself
-
+None, for now at least :)
 
 ### Disclaimer
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -72,3 +72,7 @@ msgstr ""
 msgctxt "#32013"
 msgid "Verify SSL connections"
 msgstr ""
+
+msgctxt "#32014"
+msgid "Debug HTTP requests"
+msgstr ""

--- a/resources/lib/kodi/kodilogging.py
+++ b/resources/lib/kodi/kodilogging.py
@@ -10,6 +10,15 @@ import xbmcaddon
 
 from resources.lib.tubecast.utils import PY3
 
+LEVEL_MAP = {
+    logging.CRITICAL: xbmc.LOGFATAL,
+    logging.ERROR: xbmc.LOGERROR,
+    logging.WARNING: xbmc.LOGWARNING,
+    logging.INFO: xbmc.LOGINFO,
+    logging.DEBUG: xbmc.LOGDEBUG,
+    logging.NOTSET: xbmc.LOGNONE,
+}
+
 
 class KodiLogHandler(logging.StreamHandler):
 
@@ -23,19 +32,11 @@ class KodiLogHandler(logging.StreamHandler):
         self.setFormatter(formatter)
 
     def emit(self, record):
-        levels = {
-            logging.CRITICAL: xbmc.LOGFATAL,
-            logging.ERROR: xbmc.LOGERROR,
-            logging.WARNING: xbmc.LOGWARNING,
-            logging.INFO: xbmc.LOGINFO,
-            logging.DEBUG: xbmc.LOGDEBUG,
-            logging.NOTSET: xbmc.LOGNONE,
-        }
         try:
-            xbmc.log(self.format(record), levels[record.levelno])
+            xbmc.log(self.format(record), LEVEL_MAP[record.levelno])
         except UnicodeEncodeError:
             xbmc.log(self.format(record).encode(
-                'utf-8', 'ignore'), levels[record.levelno])
+                'utf-8', 'ignore'), LEVEL_MAP[record.levelno])
 
     def flush(self):
         pass
@@ -46,6 +47,11 @@ def config():
     logger.addHandler(KodiLogHandler())
     logger.setLevel(logging.DEBUG)
 
+    # urllib3 makes a lot of unhelpful noise
+    # (POST logs don't show the body for example)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
-def get_logger():
-    return logging.getLogger(xbmcaddon.Addon().getAddonInfo('id'))
+
+def get_logger(name="general"):
+    return logging.getLogger(name)
+

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
-from resources.lib.kodi import kodilogging
+import xbmc
+
 from resources.lib.kodi.utils import get_setting_as_bool
 from resources.lib.tubecast.chromecast import Chromecast
 from resources.lib.tubecast.kodicast import Kodicast, generate_uuid
 from resources.lib.tubecast.ssdp import SSDPserver
 
-import xbmc
-
-
-logger = kodilogging.get_logger()
 monitor = xbmc.Monitor()
 
 

--- a/resources/lib/tubecast/chromecast.py
+++ b/resources/lib/tubecast/chromecast.py
@@ -13,7 +13,8 @@ from resources.lib.tubecast.dial import app
 
 import socket
 
-logger = kodilogging.get_logger()
+
+logger = kodilogging.get_logger("chromecast")
 
 
 class SilentWSGIRequestHandler(WSGIRequestHandler):

--- a/resources/lib/tubecast/dial.py
+++ b/resources/lib/tubecast/dial.py
@@ -6,8 +6,6 @@ from resources.lib.tubecast.kodicast import Kodicast
 from resources.lib.tubecast.utils import build_template
 from resources.lib.tubecast.youtube.app import YoutubeCastV1
 
-logger = kodilogging.get_logger()
-
 __device__ = '''<?xml version="1.0" encoding="utf-8"?>
 <root xmlns="urn:schemas-upnp-org:device-1-0" xmlns:r="urn:restful-tv-org:schemas:upnp-dd">
     <specVersion>

--- a/resources/lib/tubecast/ssdp.py
+++ b/resources/lib/tubecast/ssdp.py
@@ -16,7 +16,7 @@ else:
     from SocketServer import DatagramRequestHandler, ThreadingUDPServer
 
 
-logger = kodilogging.get_logger()
+logger = kodilogging.get_logger("ssdp")
 
 
 def get_interface_address(if_name):

--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -10,9 +10,9 @@ from resources.lib.kodi import kodilogging
 from resources.lib.kodi.utils import get_device_id, get_setting_as_bool
 from resources.lib.tubecast.utils import PY3
 from resources.lib.tubecast.youtube import kodibrigde
-from resources.lib.tubecast.youtube.player import CastPlayer
+from resources.lib.tubecast.youtube.player import CastPlayer, STATUS_STOPPED, STATUS_LOADING
 from resources.lib.tubecast.youtube.templates import YoutubeTemplates
-from resources.lib.tubecast.youtube.utils import case, parse_cmd
+from resources.lib.tubecast.youtube.utils import CommandParser
 from resources.lib.tubecast.youtube.volume import VolumeMonitor
 
 if PY3:
@@ -27,6 +27,73 @@ monitor = xbmc.Monitor()
 templates = YoutubeTemplates()
 
 
+class CastState(object):
+    def __init__(self):
+        self.ctt = None  # type: Optional[str]
+
+        self.playlist_id = None  # type: Optional[str]
+        self.playlist = None  # type: List[str]
+        self.playlist_index = None  # type: Optional[int]
+
+    @property
+    def video_id(self):  # type: () -> Optional[str]
+        if not self.has_playlist:
+            return None
+
+        return self.playlist[self.playlist_index]
+
+    @property
+    def has_playlist(self):  # type: () -> bool
+        return bool(self.playlist)
+
+    def handle_set_playlist(self, data):
+        self.ctt = data["ctt"]
+        # self.video_id = data["videoId"]
+
+        self.playlist_id = data["listId"]
+        self.playlist = data["videoIds"].split(",")
+        self.playlist_index = int(data["currentIndex"])
+
+    def handle_update_playlist(self, data):
+        video_ids = data.get("videoIds")
+        if not video_ids:
+            self.playlist = None
+            self.playlist_index = None
+            return
+
+        self.playlist = video_ids.split(",")
+        if self.playlist_index is not None and self.playlist_index >= len(self.playlist):
+            self.playlist_index = len(self.playlist) - 1
+
+    def _change_playlist_index(self, change):  # type: (int) -> bool
+        if not self.has_playlist:
+            return False
+
+        next_index = self.playlist_index + change
+        if not 0 <= next_index < len(self.playlist):
+            return False
+
+        self.playlist_index = next_index
+        return True
+
+    def playlist_next(self):  # type: () -> bool
+        return self._change_playlist_index(1)
+
+    def playlist_prev(self):  # type: () -> bool
+        return self._change_playlist_index(-1)
+
+    def now_playing_data(self, current_time, status_code):  # type: (int, int) -> dict
+        if not self.has_playlist:
+            return {}
+
+        return {"videoId": self.video_id,
+                "currentTime": str(current_time),
+                "ctt": self.ctt,
+                "listId": self.playlist_id,
+                "currentIndex": self.playlist_index,
+                "state": str(status_code)}
+
+
 class YoutubeCastV1(object):
 
     def __init__(self, dial=None):
@@ -34,9 +101,10 @@ class YoutubeCastV1(object):
         self.default_screen_name = get_device_id()
         self.default_screen_app = "kodi-tubecast"
         self.screen_uid = "c8277ac4-ke86-4f8b-8fe2-1236bef43397"
-        self.pairing_code = None
-        self.player = None
-        self.bind_vals = None
+
+        self.session = requests.Session()
+        self.player = None  # type: Optional[CastPlayer]
+        self.volume_monitor = None  # type: Optional[VolumeMonitor]
         self.listener = None  # type: Optional[YoutubeListener]
 
         # Set initial state
@@ -47,26 +115,19 @@ class YoutubeCastV1(object):
             self._setup_routes(dial)
 
     def _initial_app_state(self):
-        self.session = requests.Session()
-        self.ctt = None
-        self.cur_list_id = None
-        self.cur_video = None
         self.current_index = None
-        self.list_info = None
-        self.play_state = 0
         self.screen_id = None
         self.lounge_token = None
-        self.session_id = None
-        self.sid = None
         self.ofs = 0
         self.has_client = False
-        self.volume_monitor = None
         self.__replace_listener(None)
         self.connected_client = None
         # Hold references to the index of received codes
         self.code = -1
         # Get service announcement data
         self.bind_vals = templates.announcement(self.screen_uid, self.default_screen_name, self.default_screen_app)
+
+        self.state = CastState()
 
     def __replace_listener(self, listener):  # type: (Optional[YoutubeListener]) -> None
         """Replace the current listener with a new one.
@@ -105,24 +166,23 @@ class YoutubeCastV1(object):
         return ""
 
     def _pair(self, pairing_code):
-        ''' called as part of service discovery '''
-        self.pairing_code = pairing_code
+        """ called as part of service discovery """
         self._generate_screen_id()
         self._get_lounge_token_batch()
         self._bind()
-        self._register_pairing_code()
+        self._register_pairing_code(pairing_code)
         # Listen to remote youtube server
         self.__replace_listener(YoutubeListener(app=self, ssdp=True))
 
     def pair(self):
-        ''' called from external pairing_code generation script '''
+        """ called from external pairing_code generation script """
         self._generate_screen_id()
         self._get_lounge_token_batch()
         self._bind()
-        self.pairing_code = self._get_pairing_code()
+        pairing_code = self._get_pairing_code()
         # Listen to remote youtube server
         self.__replace_listener(YoutubeListener(app=self, ssdp=False))
-        return self.pairing_code
+        return pairing_code
 
     def _generate_screen_id(self):
         screen_id = self.session.get(
@@ -153,19 +213,19 @@ class YoutubeCastV1(object):
             data={"count": "0"},
             verify=get_setting_as_bool("verify-ssl")
         ).text
-        for line in bind_info.split("\n"):
-            self.handle_cmd(str(line))
+        for cmd in CommandParser(bind_info):
+            self.handle_cmd(cmd)
 
-    def _register_pairing_code(self):
+    def _register_pairing_code(self, pairing_code):  # type: (str) -> None
         r = self.session.post(
             "{}/api/lounge/pairing/register_pairing_code".format(self.base_url),
             data={
                 "access_type": "permanent",
                 "app": self.default_screen_app,
-                "pairing_code": self.pairing_code,
+                "pairing_code": pairing_code,
                 "screen_id": self.screen_id,
                 "screen_name": self.default_screen_name
-                },
+            },
             verify=get_setting_as_bool("verify-ssl")
         )
         logger.debug("Registered pairing code status code: {}".format(r.status_code))
@@ -184,232 +244,182 @@ class YoutubeCastV1(object):
         )
         return "{}-{}-{}-{}".format(r.text[0:3], r.text[3:6], r.text[6:9], r.text[9:12])
 
-    def handle_cmd(self, cmd):
-        if get_setting_as_bool('debug-cmd'):
-            logger.debug("CMD: {}".format(cmd))
+    def handle_cmd(self, cmd):  # type: (Command) -> None
+        debug_cmds = get_setting_as_bool('debug-cmd')
 
-        if case("c", cmd):
+        if debug_cmds:
+            logger.debug("CMD: %s", cmd)
+
+        code, name, data = cmd
+
+        if code <= self.code:
+            if debug_cmds:
+                logger.debug("Command ignored, already executed before")
+            return
+        
+        self.code = code
+
+        if name == "c":
             logger.debug("C cmd received")
-            self.sid = re.findall('"c","(.+?)"', cmd)[0]
-            self.bind_vals["SID"] = self.sid
+            self.bind_vals["SID"] = data[0]
 
-        elif case("S", cmd):
+        elif name == "S":
             logger.debug("Session established received")
-            self.session_id = re.findall('"S","(.+?)"', cmd)[0]
-            self.bind_vals["gsessionid"] = self.session_id
+            self.bind_vals["gsessionid"] = data
 
-        elif case("remoteConnected", cmd):
-            # Parse data
-            code, data = parse_cmd(cmd)
-            if code > self.code:
-                self.code = code
-                logger.info("Remote connected: {}".format(data))
-                self.has_client = True
-                if not self.player:
-                    # Start "player" thread
-                    threading.Thread(name="Player",
-                                     target=self.__player_thread).start()
-                # Start a new volume_monitor if not yet available
-                if not self.volume_monitor:
-                    threading.Thread(name="VolumeMonitor",
-                                     target=self.__monitor_volume).start()
-                # Disable automatic playback from youtube (this is kodi not youtube :))
-                self._set_disabled()
-                # Check if it is a new association
-                if not self.connected_client or self.connected_client != data:
-                    self.connected_client = data
-                    kodibrigde.remote_connected(data["name"])
-            else:
-                logger.debug("Command ignored, already executed before")
+        elif name == "remoteConnected":
+            logger.info("Remote connected: {}".format(data))
+            if not self.player:
+                # Start "player" thread
+                threading.Thread(name="Player",
+                                 target=self.__player_thread).start()
+            # Start a new volume_monitor if not yet available
+            if not self.volume_monitor:
+                self.volume_monitor = VolumeMonitor(self)
+                self.volume_monitor.start()
 
-        elif case("remoteDisconnected", cmd):
-            code, data = parse_cmd(cmd)
-            if code > self.code:
-                self.code = code
-                logger.info("Remote disconnected: {}".format(data))
-                self._initial_app_state()
-                kodibrigde.remote_disconnected(data["name"])
-                # Kill player if exists
-                if self.player and self.player.isPlaying:
-                    self._ready()
-            else:
-                logger.debug("Command ignored, already executed before")
+            # Disable automatic playback from youtube (this is kodi not youtube :))
+            # TODO: add setting for this.
+            self._set_disabled()
+            # Check if it is a new association
+            if self.connected_client != data:
+                self.connected_client = data
+                kodibrigde.remote_connected(data["name"])
 
-        elif case("getNowPlaying", cmd):
+        elif name == "remoteDisconnected":
+            logger.info("Remote disconnected: {}".format(data))
+            self._initial_app_state()
+            kodibrigde.remote_disconnected(data["name"])
+
+        elif name == "getNowPlaying":
             logger.debug("getNowPlaying received")
-            self._ready()
+            self.report_now_playing()
 
-        elif case("setPlaylist", cmd):
-            code, data = parse_cmd(cmd)
-            if code > self.code:
-                self.code = code
-                logger.debug("setPlaylist: {}".format(data))
-                cur_video_id = data["videoId"]
-                video_ids = data["videoIds"]
-                if 'ctt' in data:
-                    self.ctt = data["ctt"]
-                self.cur_list_id = data["listId"]
-                self.current_index = int(data["currentIndex"])
-                self.cur_list = video_ids.split(",")
-                # Set info on our custom player instance and request playback
-                self.player.setInfo(cur_video_id, self.ctt, self.cur_list_id, self.current_index)
-                play_url = kodibrigde.get_youtube_plugin_path(cur_video_id, seek=data.get("currentTime", 0))
-                self.player.play_from_youtube(play_url)
-            else:
-                logger.debug("Command ignored, already executed before")
+        elif name == "setPlaylist":
+            logger.debug("setPlaylist: {}".format(data))
+            self.state.handle_set_playlist(data)
+            play_url = kodibrigde.get_youtube_plugin_path(self.state.video_id, seek=data.get("currentTime", 0))
+            self.player.play_from_youtube(play_url)
 
-        elif case("updatePlaylist", cmd):
-            code, data = parse_cmd(cmd)
-            if code > self.code:
-                self.code = code
-                logger.debug("updatePlaylist: {}".format(data))
-                if "videoIds" in list(data.keys()):
-                    self.cur_list = data["videoIds"].split(",")
-                    if self.current_index and self.current_index >= len(self.cur_list):
-                        self.current_index -= 1
-                else:
-                    self.cur_list = []
-                    self.current_index = 0
-                    # Check if kodi is playing and if so request stop
-                    if self.player.playing:
-                        self.player.stop()
-            else:
-                logger.debug("Command ignored, already executed before")
+        elif name == "updatePlaylist":
+            logger.debug("updatePlaylist: {}".format(data))
+            self.state.handle_update_playlist(data)
+            if not self.state.has_playlist:
+                if self.player.playing:
+                    self.player.stop()
 
-        elif case("next", cmd):
+        elif name == "next":
             logger.debug("Next received")
-            if self.current_index + 1 < len(self.cur_list):
-                self._next()
+            self._next()
 
-        elif case("previous", cmd):
+        elif name == "previous":
             logger.debug("Previous received")
-            if self.current_index > 0:
-                self._previous()
+            self._previous()
 
-        elif case("pause", cmd):
+        elif name == "pause":
             logger.debug("Pause received")
             self._pause()
 
-        elif case("stopVideo", cmd):
+        elif name == "stopVideo":
             logger.debug("stopVideo received")
+            # FIXME: this doesn't stop the video
             if self.player and self.player.playing:
-                self._ready()
+                self.report_now_playing()
 
-        elif case("seekTo", cmd):
-            code, data = parse_cmd(cmd)
-            if code > self.code:
-                self.code = code
-                logger.debug("seekTo: {}".format(data))
-                time_seek = data["newTime"]
-                self._seek(time_seek)
-            else:
-                logger.debug("Command ignored, already executed before")
+        elif name == "seekTo":
+            logger.debug("seekTo: {}".format(data))
+            self._seek(int(data["newTime"]))
 
-        elif case("getVolume", cmd):
+        elif name == "getVolume":
             logger.debug("getVolume received")
-            self._get_volume()
+            volume = kodibrigde.get_kodi_volume()
+            self.report_volume(volume)
 
-        elif case("setVolume", cmd):
-            code, data = parse_cmd(cmd)
-            if code > self.code:
-                self.code = code
-                logger.debug("setVolume: {}".format(data))
-                new_volume = data["volume"]
-                # Set volume only if it differs from current volume
-                if new_volume != kodibrigde.get_kodi_volume():
-                    self._set_volume(new_volume)
-            else:
-                logger.debug("Command ignored, already executed before")
+        elif name == "setVolume":
+            logger.debug("setVolume: {}".format(data))
+            new_volume = data["volume"]
+            # Set volume only if it differs from current volume
+            if new_volume != kodibrigde.get_kodi_volume():
+                self._set_volume(new_volume)
 
-        elif case("play", cmd):
+        elif name == "play":
             logger.debug("play received")
-            self.play_state = 1
             self._resume()
+        elif debug_cmds:
+            logger.debug("unhandled command: %r", name)
 
     def _resume(self):
         if not self.player.playing and self.player.isPlaying():
             # Resume playback
             self.player.pause()
 
-    def _seek(self, time_seek):
+    def _seek(self, time_seek):  # type: (int) -> None
         if self.player.isPlaying():
-            # Inform the app that we're loading (state=3).
-            # This isn't just for the user experience, it's actually required
-            # to make the app update it's progress (It only seems to work when the state changes)
-            self.__send_state_change(time_seek, self.player.getTotalTime(), state=3)
-            self.player.seekTime(int(time_seek))
+            # Inform the app that we're loading.
+            self.report_state_change(STATUS_LOADING, time_seek, self.player.getTotalTime())
+            self.player.seekTime(time_seek)
 
     def _pause(self):
         if self.player.playing:
             self.player.pause()
 
     def _previous(self):
-        self.current_index -= 1
-        cur_video_id = self.cur_list[self.current_index]
-        self.player.setInfo(cur_video_id, self.ctt, self.cur_list_id, self.current_index)
-        self.player.play_from_youtube(kodibrigde.get_youtube_plugin_path(cur_video_id))
+        if not self.state.playlist_prev():
+            return
+
+        self.player.play_from_youtube(kodibrigde.get_youtube_plugin_path(self.state.video_id))
 
     def _next(self):
-        self.current_index += 1
-        cur_video_id = self.cur_list[self.current_index]
-        self.player.setInfo(cur_video_id, self.ctt, self.cur_list_id, self.current_index)
-        self.player.play_from_youtube(kodibrigde.get_youtube_plugin_path(cur_video_id))
+        if not self.state.playlist_next():
+            return
 
-    def _ready(self):
-        threading.Thread(name="POST nowPlaying",
-                         target=self.__post_bind,
-                         args=["nowPlaying", {}]).start()
-
-    def pause(self, time, duration):
-        self.play_state = 2
-        self.__send_state_change(time, duration)
+        self.player.play_from_youtube(kodibrigde.get_youtube_plugin_path(self.state.video_id))
 
     def _set_disabled(self):
         self.__post_bind("onAutoplayModeChanged", {"autoplayMode": "ENABLED"})
 
-    def report_playback_ended(self):
-        # Inform current state (stopped)
-        self.__send_state_change(0, 0, state=4)
-        if self.cur_list and isinstance(self.current_index, int) and self.current_index + 1 < len(self.cur_list):
-            self._next()
-        else:
-            self._ready()
-
-    def report_playback_started(self, video_id, current_time, ctt, list_id, current_index):
-        logger.debug("Report playback started")
-        self.__post_bind("nowPlaying", {"videoId": video_id, "currentTime": current_time, "ctt": ctt, "listId": list_id, "currentIndex": int(current_index), "state": "3"})
-
-    def report_playing_time(self, play_state, current_time, duration):
-        logger.debug("Report playback current time")
-        self.play_state = play_state
-        self.__send_state_change(current_time, duration)
-
-    def _get_volume(self):
-        volume = kodibrigde.get_kodi_volume()
-        threading.Thread(name="POST onVolumeChanged",
-                         target=self.__post_bind,
-                         args=["onVolumeChanged", {"volume": str(volume), "muted": "false"}]).start()
-
-    def set_volume(self, volume):
-        self._get_volume()
-
     def _set_volume(self, volume):
         kodibrigde.set_kodi_volume(int(volume))
-        threading.Thread(name="POST onVolumeChanged",
-                         target=self.__post_bind,
-                         args=["onVolumeChanged", {"volume": str(volume), "muted": "false"}]).start()
+        self.report_volume(volume)
 
-    def __send_state_change(self, current_time, duration, state=None):  # type: (float, float, int) -> None
-        if state is None:
-            state = self.play_state
-        self.__post_bind("onStateChange", {"currentTime": str(current_time), "state": str(state), "duration": str(duration), "cpn": "foo"})
+    def report_now_playing(self):
+        if self.player and self.player.isPlaying():
+            data = self.state.now_playing_data(int(self.player.getTime()), self.player.status_code)
+        else:
+            data = {}
 
-    def __post_bind(self, sc, postdata):
+        self.__post_bind("nowPlaying", data)
+
+    def report_playback_ended(self):
+        # Inform current state (stopped)
+        self.report_state_change(STATUS_STOPPED, 0, 0)
+        if self.state.playlist_next():
+            self.player.play_from_youtube(kodibrigde.get_youtube_plugin_path(self.state.video_id))
+        else:
+            self.report_now_playing()
+
+    def report_playback_started(self, current_time):  # type: (int) -> None
+        logger.debug("Report playback started")
+        self.__post_bind("nowPlaying", self.state.now_playing_data(current_time, STATUS_LOADING))
+
+    def report_volume(self, volume):  # type: (int) -> None
+        self.__post_bind("onVolumeChanged", {"volume": str(volume), "muted": "false"})
+
+    def report_state_change(self, state, current_time, duration):  # type: (int, int, int) -> None
+        self.__post_bind("onStateChange",
+                         {"currentTime": str(current_time),
+                          "state": str(state),
+                          "duration": str(duration),
+                          "cpn": "foo"})
+
+    def __post_bind(self, sc, postdata):  # type: (str, dict) -> None
         self.ofs += 1
-        post_data = {"count": "1", "ofs": str(self.ofs)}
-        post_data["req0__sc"] = sc
-        for key in list(postdata.keys()):
+        post_data = {"count": "1", "ofs": str(self.ofs), "req0__sc": sc}
+        for key in postdata.keys():
             post_data["req0_" + key] = postdata[key]
+
+        # TODO add setting
+        logger.debug("POST %s:\n%r", sc, post_data)
 
         bind_vals = self.bind_vals
         bind_vals["RID"] = "1337"
@@ -430,7 +440,7 @@ class YoutubeCastV1(object):
         return r.json()["video"]
 
     def __player_thread(self):
-        self.player = CastPlayer(youtubecastv1=self)
+        self.player = CastPlayer(cast=self)
         while not monitor.abortRequested() and self.has_client:
             monitor.waitForAbort(1)
 
@@ -439,11 +449,6 @@ class YoutubeCastV1(object):
         if self.listener:
             self.listener.force_stop()
             self.listener.join()
-
-    def __monitor_volume(self):
-        self.volume_monitor = VolumeMonitor(self)
-        while self.has_client and not self.volume_monitor.abortRequested():
-            self.volume_monitor.waitForAbort(1)
 
 
 class YoutubeListener(threading.Thread):
@@ -455,10 +460,10 @@ class YoutubeListener(threading.Thread):
         self.ssdp = ssdp
         self.r = None  # type: Optional[requests.Response]
 
-    def __read_cmd_lines(self, url):  # type: (str) -> Iterator[str]
+    def __read_cmd_chunks(self, url):  # type: (str) -> Iterator[str]
         with self.app.session.get(url, stream=True) as self.r:
             try:
-                for line in self.r.iter_lines():
+                for line in self.r.iter_content(chunk_size=None):
                     if self.stop:
                         break
 
@@ -478,8 +483,14 @@ class YoutubeListener(threading.Thread):
         bind_vals["TYPE"] = "xmlhttp"
         bind_vals["AID"] = "3"
         url = "{}/api/lounge/bc/bind?{}".format(self.app.base_url, urlencode(bind_vals))
-        for line in self.__read_cmd_lines(url):
-            self.app.handle_cmd(line)
+
+        parser = CommandParser()
+        for chunk in self.__read_cmd_chunks(url):
+            # TODO add setting for all request related logs
+            logger.debug("received chunk %r", chunk)
+            parser.write(chunk)
+            for cmd in parser.get_commands():
+                self.app.handle_cmd(cmd)
 
     def run(self):
         while not self.stop and (not self.ssdp or self.app.has_client):
@@ -494,4 +505,3 @@ class YoutubeListener(threading.Thread):
             sock.shutdown(socket.SHUT_RDWR)
             sock.close()
             # request cleanup is handled by __read_cmd_lines
-

--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -304,9 +304,8 @@ class YoutubeCastV1(object):
         elif name == "updatePlaylist":
             logger.debug("updatePlaylist: {}".format(data))
             self.state.handle_update_playlist(data)
-            if not self.state.has_playlist:
-                if self.player.playing:
-                    self.player.stop()
+            if not self.state.has_playlist and self.player.isPlaying():
+                self.player.stop()
 
         elif name == "next":
             logger.debug("Next received")
@@ -322,9 +321,8 @@ class YoutubeCastV1(object):
 
         elif name == "stopVideo":
             logger.debug("stopVideo received")
-            # FIXME: this doesn't stop the video
-            if self.player and self.player.playing:
-                self.report_now_playing()
+            if self.player.isPlaying():
+                self.player.stop()
 
         elif name == "seekTo":
             logger.debug("seekTo: {}".format(data))

--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -350,7 +350,7 @@ class YoutubeCastV1(object):
 
     def _resume(self):
         if not self.player.playing and self.player.isPlaying():
-            # Resume playback
+            # Toggle playback to resume
             self.player.pause()
 
     def _seek(self, time_seek):  # type: (int) -> None
@@ -418,8 +418,8 @@ class YoutubeCastV1(object):
         for key in postdata.keys():
             post_data["req0_" + key] = postdata[key]
 
-        # TODO add setting
-        logger.debug("POST %s:\n%r", sc, post_data)
+        if get_setting_as_bool("debug-http"):
+            logger.debug("POST %s:\n%r", sc, post_data)
 
         bind_vals = self.bind_vals
         bind_vals["RID"] = "1337"
@@ -484,10 +484,13 @@ class YoutubeListener(threading.Thread):
         bind_vals["AID"] = "3"
         url = "{}/api/lounge/bc/bind?{}".format(self.app.base_url, urlencode(bind_vals))
 
+        debug_http = get_setting_as_bool("debug-http")
+
         parser = CommandParser()
         for chunk in self.__read_cmd_chunks(url):
-            # TODO add setting for all request related logs
-            logger.debug("received chunk %r", chunk)
+            if debug_http:
+                logger.debug("received chunk %r", chunk)
+
             parser.write(chunk)
             for cmd in parser.get_commands():
                 self.app.handle_cmd(cmd)

--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -77,9 +77,21 @@ class CastState(object):
         return True
 
     def playlist_next(self):  # type: () -> bool
+        """Advance to the next video in the playlist.
+
+        Returns:
+            Whether the operation succeeded.
+            `False` if there is no playlist or we're on the last video.
+        """
         return self._change_playlist_index(1)
 
     def playlist_prev(self):  # type: () -> bool
+        """Go to the previous video in the playlist.
+
+        Returns:
+            Whether the operation succeeded.
+            `False` if there is no playlist or we're on the first video.
+        """
         return self._change_playlist_index(-1)
 
     def now_playing_data(self, current_time, status_code):  # type: (int, int) -> dict

--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from resources.lib.kodi import kodilogging
-
 import xbmc
 
+from resources.lib.kodi import kodilogging
+
 monitor = xbmc.Monitor()
+logger = kodilogging.get_logger("player")
 
 STATUS_PLAYING = 1
 STATUS_PAUSED = 2
@@ -24,8 +25,13 @@ class CastPlayer(xbmc.Player):
 
     @property
     def status_code(self):  # type: () -> int
-        # TODO add more states
-        return STATUS_PAUSED if xbmc.getCondVisibility('Player.Paused') else STATUS_PLAYING
+        if xbmc.getCondVisibility("Player.Paused"):
+            return STATUS_PAUSED
+
+        if self.isPlaying():
+            return STATUS_PLAYING
+
+        return STATUS_STOPPED
 
     @property
     def playing(self):  # type: () -> bool
@@ -74,6 +80,7 @@ class CastPlayer(xbmc.Player):
         self.__report_state_change(status_code=STATUS_LOADING)
 
     def onPlayBackStopped(self):
+        logger.debug("stopped by user")
         # FIXME: This should probably behave differently than when the video ends naturally...
         if self.cast.has_client:
             self.onPlayBackEnded()

--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -39,22 +39,20 @@ class CastPlayer(xbmc.Player):
     def __should_report(self):  # type: () -> bool
         return self.cast.has_client and self.from_yt
 
-    def __report_state_change(self):
+    def __report_state_change(self, status_code=None):
         if not self.__should_report():
             return
 
-        self.cast.report_state_change(self.status_code, int(self.getTime()), int(self.getTotalTime()))
+        if status_code is None:
+            status_code = self.status_code
+
+        self.cast.report_state_change(status_code, int(self.getTime()), int(self.getTotalTime()))
 
     def onPlayBackStarted(self):
         if not self.__should_report():
             return
 
-        try:
-            playing_time = int(self.getTime())
-        except Exception:
-            playing_time = 0
-
-        self.cast.report_playback_started(playing_time)
+        self.cast.report_now_playing()
 
         while self.isPlaying() and self.__should_report() and not monitor.abortRequested():
             self.__report_state_change()
@@ -73,7 +71,7 @@ class CastPlayer(xbmc.Player):
         self.from_yt = False
 
     def onPlayBackSeek(self, time, seek_offset):
-        self.__report_state_change()
+        self.__report_state_change(status_code=STATUS_LOADING)
 
     def onPlayBackStopped(self):
         # FIXME: This should probably behave differently than when the video ends naturally...

--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -80,7 +80,5 @@ class CastPlayer(xbmc.Player):
         self.__report_state_change(status_code=STATUS_LOADING)
 
     def onPlayBackStopped(self):
-        logger.debug("stopped by user")
-        # FIXME: This should probably behave differently than when the video ends naturally...
-        if self.cast.has_client:
-            self.onPlayBackEnded()
+        if self.__should_report():
+            self.cast.report_playback_stopped()

--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -17,7 +17,6 @@ class CastPlayer(xbmc.Player):
         self.cast = cast
         # auxiliary variable to know if the request came from the youtube background thread
         self.from_yt = False
-        self.playing = False
 
     def play_from_youtube(self, url):  # type: (str) -> None
         self.from_yt = True
@@ -28,6 +27,10 @@ class CastPlayer(xbmc.Player):
         # TODO add more states
         return STATUS_PAUSED if xbmc.getCondVisibility('Player.Paused') else STATUS_PLAYING
 
+    @property
+    def playing(self):  # type: () -> bool
+        return xbmc.getCondVisibility("Player.Playing")
+
     def _should_report(self):  # type: () -> bool
         return self.cast.has_client and self.from_yt
 
@@ -35,8 +38,6 @@ class CastPlayer(xbmc.Player):
         self.cast.report_state_change(self.status_code, int(self.getTime()), int(self.getTotalTime()))
 
     def onPlayBackStarted(self):
-        self.playing = True
-
         if not self._should_report():
             return
 
@@ -52,17 +53,14 @@ class CastPlayer(xbmc.Player):
             monitor.waitForAbort(5)
 
     def onPlayBackResumed(self):
-        self.playing = True
         if self._should_report():
             self.__report_state_change()
 
     def onPlayBackPaused(self):
-        self.playing = False
         if self._should_report():
             self.__report_state_change()
 
     def onPlayBackEnded(self):
-        self.playing = False
         if self._should_report():
             self.cast.report_playback_ended()
 

--- a/resources/lib/tubecast/youtube/utils.py
+++ b/resources/lib/tubecast/youtube/utils.py
@@ -1,27 +1,60 @@
 # -*- coding: utf-8 -*-
 import ast
 import re
+from collections import namedtuple
+
+from resources.lib.kodi import kodilogging
+
+logger = kodilogging.get_logger()
+
+Command = namedtuple("Command", ("code", "name", "data"))
 
 
-def case(identifier, cmd):
-    return '"%s"' % identifier in str(cmd)
-
-
-def parse_cmd(cmd):
-    cmd = re.compile(r'(\d+),\[".+?",(.*)\]\]').findall(cmd.decode("utf-8"))
-    if cmd:
-        code = cmd[0][0]
-        cmd = ast.literal_eval(
-            "{}".format(
-                cmd[0][1]
-                .replace('"{', '{')
-                .replace('}"', '}')
-                .replace('\\"', '"')
-                )
-            )
-        return int(code), cmd
+def _command_from_match(match):
+    code = int(match.group("code"))
+    name = match.group("cmd")
+    raw_data = match.group("data")
+    if raw_data:
+        data = ast.literal_eval(raw_data)
     else:
-        raise ValueError('Unable to parse CMD')
+        data = None
+
+    return Command(code, name, data)
+
+
+CMD_PATTERN = re.compile(r"\[(?P<code>\d+),\[\"(?P<cmd>.+?)\"(?:,(?P<data>.*?))?\]\]")
+
+
+class CommandParser:
+    def __init__(self, buf=None):
+        self.pending = ""
+
+        if buf:
+            self.write(buf)
+
+    def __iter__(self):
+        return self._parse_pending()
+
+    def _parse_pending(self):
+        if not self.pending:
+            return
+
+        for match in CMD_PATTERN.finditer(self.pending):
+            self.pending = self.pending[match.end():]
+
+            try:
+                cmd = _command_from_match(match)
+            except SyntaxError:
+                logger.exception("unable to parse command")
+            else:
+                yield cmd
+
+    def write(self, s):  # type: (str) -> None
+        for line in s.splitlines():
+            self.pending += line
+
+    def get_commands(self):  # type: () -> List[Command]
+        return list(self)
 
 
 def get_video_list(data):

--- a/resources/lib/tubecast/youtube/utils.py
+++ b/resources/lib/tubecast/youtube/utils.py
@@ -28,9 +28,9 @@ CMD_PATTERN = re.compile(r"\[(?P<code>\d+),\[\"(?P<cmd>.+?)\"(?:,(?P<data>.*?))?
 
 
 class CommandParser:
-    """
+    """Buffering stream parser for YouTube Cast commands.
 
-    .. warning:: This class isn't thread-safe!
+    Warnings: This class isn't thread-safe!
     """
 
     def __init__(self, buf=None):

--- a/resources/lib/tubecast/youtube/volume.py
+++ b/resources/lib/tubecast/youtube/volume.py
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
 import json
-
-from resources.lib.kodi import kodilogging
-from resources.lib.tubecast.youtube import kodibrigde
+import threading
 
 import xbmc
 
-
-logger = kodilogging.get_logger()
+from resources.lib.tubecast.youtube import kodibrigde
 
 
 class VolumeMonitor(xbmc.Monitor):
 
-    def __init__(self, youtubecastv1):
-        self.youtubecastv1 = youtubecastv1
+    def __init__(self, cast):
+        super(VolumeMonitor, self).__init__()
+        self.cast = cast
         self.kodi_volume = kodibrigde.get_kodi_volume()
 
+        self.thread = None
+
     def onNotification(self, sender, method, data):
-        if self.youtubecastv1.has_client and method == "Application.OnVolumeChanged":
+        if self.cast.has_client and method == "Application.OnVolumeChanged":
             new_volume = json.loads(data)["volume"]
             if self.kodi_volume != new_volume:
                 self.kodi_volume = new_volume

--- a/resources/lib/tubecast/youtube/volume.py
+++ b/resources/lib/tubecast/youtube/volume.py
@@ -21,4 +21,12 @@ class VolumeMonitor(xbmc.Monitor):
             new_volume = json.loads(data)["volume"]
             if self.kodi_volume != new_volume:
                 self.kodi_volume = new_volume
-                self.youtubecastv1.set_volume(new_volume)
+                self.cast.report_volume(new_volume)
+
+    def start(self):
+        self.thread = threading.Thread(name="VolumeMonitor", target=self.__run)
+        self.thread.start()
+
+    def __run(self):
+        while self.cast.has_client and not self.abortRequested():
+            self.waitForAbort(1)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,5 +7,6 @@
 	<category label="32012">
 		<setting label="32005" type="bool" id="debug-ssdp" default="false"/>
 		<setting label="32011" type="bool" id="debug-cmd" default="false"/>
+		<setting label="32014" type="bool" id="debug-http" default="false"/>
 	</category>
 </settings>

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
-from resources.lib.tubecast.youtube.utils import parse_cmd
+from resources.lib.tubecast.youtube.utils import CommandParser
 
 cmd_1 = '[[20,["remoteDisconnected",{"app":"android-phone-13.05.52","pairingType":"dial","capabilities":"atp,que,mus","ui":"true","clientName":"android","experiments":"","name":"MYPHONE","remoteControllerUrl":"ws://","id":"something","type":"REMOTE_CONTROL","device":"{\"app\":\"android-phone-13.05.52\",\"pairingType\":\"dial\",\"capabilities\":\"atp,que,mus\",\"clientName\":\"android\",\"experiments\":\"\",\"name\":\"MYPHONE\",\"remoteControllerUrl\":\"ws://\",\"id\":\"id\",\"type\":\"REMOTE_CONTROL\"}"}]]'
 cmd_2 = '20,["remoteDisconnected",{"app":"android-phone-13.05.52","pairingType":"dial","capabilities":"atp,que,mus","ui":"true","clientName":"android","experiments":"","name":"MYPHONE","remoteControllerUrl":"ws://","id":"something","type":"REMOTE_CONTROL","device":"{\"app\":\"android-phone-13.05.52\",\"pairingType\":\"dial\",\"capabilities\":\"atp,que,mus\",\"clientName\":\"android\",\"experiments\":\"\",\"name\":\"MYPHONE\",\"remoteControllerUrl\":\"ws://\",\"id\":\"id\",\"type\":\"REMOTE_CONTROL\"}"}]]'
@@ -16,10 +16,14 @@ def str_to_bytes(string):
 
 
 def test_cmd1():
-    _, data = parse_cmd(str_to_bytes(cmd_1))
-    assert data["name"] == "MYPHONE"
+    cmd = next(iter(CommandParser(str_to_bytes(cmd_1))))
+    assert cmd.code == 20
+    assert cmd.name == "remoteDisconnected"
+    assert cmd.data["name"] == "MYPHONE"
 
 
 def test_cmd2():
-    _, data = parse_cmd(str_to_bytes(cmd_2))
-    assert data["name"] == "MYPHONE"
+    cmd = next(iter(CommandParser(str_to_bytes(cmd_2))))
+    assert cmd.code == 20
+    assert cmd.name == "remoteDisconnected"
+    assert cmd.data["name"] == "MYPHONE"


### PR DESCRIPTION
Hello again. It's been a few days, hasn't it?
I sure hope you haven't gotten sick of me yet because this one is probably bigger than the previous ones combined.

## New command parser

I wanted to make sure that every command is only run once. While adding the checks for all commands I noticed that the current parser is unable to parse some of the commands.
Part of the problem is that some commands are, for whatever reason, spread across multiple lines (One of the first commands always has a closing bracket on the following line for example).

The new parser is capable of parsing all commands and even tolerates the weird numbers which are sent outside of the outer list every now and then.

## Improved state management

State is currently stored all over the place.
A few particularly bad examples:
- `YoutubeCastV1` keeps a [`play_state`](https://github.com/enen92/script.tubecast/blob/f56de71ca19772bd29c87414e8082183e33f3aab/resources/lib/tubecast/youtube/app.py#L56) variable which can even go out of sync with the actual player state.
- The `CastPlayer` is [fed a bunch of information](https://github.com/enen92/script.tubecast/blob/f56de71ca19772bd29c87414e8082183e33f3aab/resources/lib/tubecast/youtube/player.py#L22) by the app but it is never actually used.  

I removed all the playlist state from the player and the app and moved it to a new class.

This will make it a lot easier to implement #29.

I also removed some variables like the pairing code or the SID from the app. These variables are only used in the context they're created in so they don't need to bloat the class.

## Changed stop behaviour

When the user presses the stop button in Kodi, TubeCast has so far treated this the same as when the player reached the end of the video. Most notably: pressing stop with a playlist would cause the next video to start playing.
This has been adjusted so that pressing stop actually causes Kodi to stop.
As long as the client stays connected the user can still start playing again without losing the playlist.  

## Logging improvements

I gave TubeCast's loggers more expressive names. Currently all of them are just called "script.tubecast" and because "[script.tubecast]" is a prefix of every log there's a lot of unnecessary repetition.
Now the default logger name is "general" with a few loggers having specialised names according to their purpose like "ssdp" and "chromecast".
I disabled the "urllib3" debug logger because it just only logs the url (and the response code) for the `__post_bind` method which isn't helpful at all. Instead the `__post_bind` now logs the opcode and data manually.

I also removed some unused loggers.

## Bugfixes

- When the user pauses playback for too long the CastPlayer would stop sending progress updates to the app because pausing sets the `playing` attribute to `False` which causes the [loop](https://github.com/enen92/script.tubecast/blob/f56de71/resources/lib/tubecast/youtube/player.py#L46) to exit.
-  Pausing on the phone but then later resuming playback on Kodi causes the video to pause every few minutes. This is because the app (for whatever reason) resends the pause command.
Thanks to the new command system all commands are only handled once, even "pause" [which previously wasn't](https://github.com/enen92/script.tubecast/blob/f56de71ca19772bd29c87414e8082183e33f3aab/resources/lib/tubecast/youtube/app.py#L276).
- I previously submitted a patch which made it possible to seek on the phone when the player is paused. I discovered that a similar issue exists when seeking on Kodi when the player is paused which means that the app doesn't update it's progress when you seek on Kodi. This has been fixed in this PR.