### PR TITLE
Use a random free port for ChromeCast server

### DIFF
--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -14,13 +14,15 @@ monitor = xbmc.Monitor()
 
 def run():
     generate_uuid()
+
+    # Start HTTP server
+    chromecast = Chromecast(monitor)
+    chromecast_addr = chromecast.start()
+
     # Start SSDP service
     if get_setting_as_bool('enable-ssdp'):
         ssdp_server = SSDPserver()
-        ssdp_server.start(interfaces=Kodicast.interfaces)
-    # Start HTTP server
-    chromecast = Chromecast(monitor)
-    chromecast.start()
+        ssdp_server.start(chromecast_addr, interfaces=Kodicast.interfaces)
 
     while not monitor.abortRequested():
         monitor.waitForAbort(1)

--- a/resources/lib/tubecast/chromecast.py
+++ b/resources/lib/tubecast/chromecast.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from threading import Thread
+import threading
+
 try:
     from socketserver import ThreadingMixIn
 except ImportError:
@@ -12,12 +13,12 @@ from resources.lib.tubecast.dial import app
 
 import socket
 
-
 logger = kodilogging.get_logger()
 
 
 class SilentWSGIRequestHandler(WSGIRequestHandler):
     """WSGI request handler with logging disabled"""
+
     def log_message(self, format, *args):
         logger.debug("{} - - {}".format(self.address_string(), format % args))
 
@@ -42,25 +43,29 @@ class Chromecast(object):
 
     def __init__(self, monitor):
         self._monitor = monitor
-        self._server_thread = Thread(name="ChromecastServer",
-                                     target=self._run_server,
-                                     args=('0.0.0.0', 8008))
+        self._server_thread = threading.Thread(name="ChromecastServer",
+                                               target=self._run_server,
+                                               args=('0.0.0.0', 0))
         self._server_thread.daemon = True
         self._server = None
+        self._has_server = threading.Event()
         self._abort_var = False
 
     def _run_server(self, host, port):
         self._server = make_server(host, port, app,
                                    server_class=ThreadedWSGIServer,
                                    handler_class=SilentWSGIRequestHandler)
+        self._has_server.set()
         self._server.timeout = 0.1
         while not self._abort_var or not self._monitor.abortRequested():
             self._server.handle_request()
 
         self._server.server_close()
 
-    def start(self):
+    def start(self):  # type: () -> Tuple[int, int]
         self._server_thread.start()
+        self._has_server.wait()
+        return tuple(self._server.socket.getsockname()[:2])
 
     def abort(self):
         self._abort_var = True


### PR DESCRIPTION
Closes #4

Implemented by starting the `Chromecast` server before the `SSDPServer`.
The chromecast address tuple (ip, port) is then passed to the `MulticastServer` where it is accessible to the datagram handler.
This has the additional benefit of removing the rather hacky `get_remote_ip` method. 