### PR TITLE
default device_id

### DIFF
--- a/resources/lib/kodi/utils.py
+++ b/resources/lib/kodi/utils.py
@@ -45,8 +45,10 @@ def set_setting(setting, value):
 
 
 def get_device_id():
-    return get_infolabel("System.FriendlyName")
-
+    friendly_name = get_infolabel("System.FriendlyName")
+    if not friendly_name:
+        friendly_name = "Kodi TV"
+    return friendly_name
 
 def get_setting_as_bool(setting):
     return get_setting(setting).lower() == "true"


### PR DESCRIPTION
**Problem description:**
I have a "Vero 4k" media player with Kodi  installed.
This setup doesn't provide an infolabel `System.FriendlyName`, so `get_device_id()` function doesn't return any value - which leads to problem in youtube app while trying to discover Chromecast player in a local network.
More details about Vero 4K & `FriendlyName`: https://discourse.osmc.tv/t/how-to-set-system-friendlyname/80829

**Change description:**
In case if there is no `System.FriendlyName` found in environment - return a default device_id = `Kodi TV`

