### PR TITLE
Set from_yt to False before reporting playback ended.

### DIFF
--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -71,10 +71,11 @@ class CastPlayer(xbmc.Player):
         self.__report_state_change()
 
     def onPlayBackEnded(self):
-        if self.__should_report():
-            self.cast.report_playback_ended()
-
+        should_report = self.__should_report()
         self.from_yt = False
+
+        if should_report:
+            self.cast.report_playback_ended()
 
     def onPlayBackSeek(self, time, seek_offset):
         self.__report_state_change(status_code=STATUS_LOADING)


### PR DESCRIPTION
This fixes #40 since it was starting the next video in the report_playback_ended call but it wasn't reporting it to youtube due to from_yt being overwritten to False after the call.