### PR TITLE
Stop the current video before starting a new one.

### DIFF
--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -20,6 +20,8 @@ class CastPlayer(xbmc.Player):
         self.from_yt = False
 
     def play_from_youtube(self, url):  # type: (str) -> None
+        if self.isPlaying():
+            self.stop()
         self.from_yt = True
         self.play(url)
 


### PR DESCRIPTION
This fixes the youtube app losing sync with the current playing video/position when starting a new video from the app while there was one already playing.

The reason why this happens is that for some reason `xbmc.Player` is reporting the old `time` and `totalTime` inside `onPlayBackStarted`, which causes `report_now_playing` to use the old values and YouTube gets confused by that.

There are other, more complicated ways to approach this issue.
The thing I don't like about this approach is that it has to wait for the player to close and than open again, but I feel like it's good enough since it doesn't take that long and it keeps things easy.