### PR TITLE
Fix crash on missing ctt key

### DIFF
--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -48,7 +48,8 @@ class CastState(object):
         return bool(self.playlist)
 
     def handle_set_playlist(self, data):
-        self.ctt = data["ctt"]
+        if 'ctt' in data:
+            self.ctt = data["ctt"]
 
         self.playlist_id = data["listId"]
         self.playlist = data["videoIds"].split(",")


### PR DESCRIPTION
Exactly as issue https://github.com/enen92/script.tubecast/pull/9 
If the `ctt` key is missing, the app crash and the video is not played. So this fix checks for the `ctt` key existence.