### PR TITLE
Fix pairing with newer version of android youtube app Tested on Leia

### DIFF
--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -235,7 +235,8 @@ class YoutubeCastV1(object):
                 "app": self.default_screen_app,
                 "pairing_code": pairing_code,
                 "screen_id": self.screen_id,
-                "screen_name": self.default_screen_name
+                "screen_name": self.default_screen_name,
+                "device_id": self.default_screen_name
             },
             verify=get_setting_as_bool("verify-ssl")
         )
@@ -249,7 +250,8 @@ class YoutubeCastV1(object):
                 "app": self.default_screen_app,
                 "lounge_token": self.lounge_token,
                 "screen_id": self.screen_id,
-                "screen_name": self.default_screen_name
+                "screen_name": self.default_screen_name,
+                "device_id": self.default_screen_name
             },
             verify=get_setting_as_bool("verify-ssl")
         )


### PR DESCRIPTION
Including self.default_screen_name as device_id under "screen_name": self.default_screen_name,


 #53 (comment)

Credits to  
ivanich and patrickkfkan


Tested working on Leia.
