### PR TITLE
Fix crash caused by non-integer seek times

### DIFF
--- a/resources/lib/tubecast/youtube/app.py
+++ b/resources/lib/tubecast/youtube/app.py
@@ -334,7 +334,7 @@ class YoutubeCastV1(object):
 
         elif name == "seekTo":
             logger.debug("seekTo: {}".format(data))
-            self._seek(int(data["newTime"]))
+            self._seek(round(float(data["newTime"])))
 
         elif name == "getVolume":
             logger.debug("getVolume received")


### PR DESCRIPTION
If I cast a video from a Chrome browser and then use the arrow keys to seek while it's playing, I often see this error on the Tubecast side:

    [script.tubecast] general: received chunk b'52\n[[12,["seekTo",{"newTime":"19.509999999999998"}]]\n]\n'
    [script.tubecast] general: command parser skipped: ']52['
    [script.tubecast] general: CMD: Command(code=12, name='seekTo', data={'newTime': '19.509999999999998'})
    [script.tubecast] general: seekTo: {'newTime': '19.509999999999998'}
    [script.tubecast] general: error while listening
    Traceback (most recent call last):
      File "/storage/.kodi/addons/script.tubecast/resources/lib/tubecast/youtube/app.py", line 522, in run
        self._listen()
      File "/storage/.kodi/addons/script.tubecast/resources/lib/tubecast/youtube/app.py", line 517, in _listen
        self.app.handle_cmd(cmd)
      File "/storage/.kodi/addons/script.tubecast/resources/lib/tubecast/youtube/app.py", line 337, in handle_cmd
        self._seek(int(data["newTime"]))
    ValueError: invalid literal for int() with base 10: '19.509999999999998'

Fix this by rounding floats to the nearest integer.